### PR TITLE
[검토요청] oauth, jwt, security관련 코드 위치입니다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,22 +29,22 @@ dependencies {
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.530'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'me.paulschwarz:spring-dotenv:2.5.4'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	// implementation 'org.springframework.boot:spring-boot-starter-security'
+	// implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-	// JWT 관련 의존성
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	// // JWT 관련 의존성
+	// implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	// runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	// runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	// Google API Client Library
-	implementation 'com.google.api-client:google-api-client:2.0.0'
+	// // Google API Client Library
+	// implementation 'com.google.api-client:google-api-client:2.0.0'
 
-	// Google OAuth Client Library
-	implementation 'com.google.oauth-client:google-oauth-client:1.34.1'
+	// // Google OAuth Client Library
+	// implementation 'com.google.oauth-client:google-oauth-client:1.34.1'
 
-	// Google HTTP Client Library (needed for OAuth)
-	implementation 'com.google.http-client:google-http-client-gson:1.42.3'
+	// // Google HTTP Client Library (needed for OAuth)
+	// implementation 'com.google.http-client:google-http-client-gson:1.42.3'
 
 	// JSON 라이브러리 추가
 	implementation 'org.json:json:20210307'

--- a/src/main/java/com/example/finalproj/config/auth/SecurityConfig.java
+++ b/src/main/java/com/example/finalproj/config/auth/SecurityConfig.java
@@ -1,36 +1,36 @@
-package com.example.finalproj.config.auth;
+// package com.example.finalproj.config.auth;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.web.SecurityFilterChain;
+// import org.springframework.context.annotation.Bean;
+// import org.springframework.context.annotation.Configuration;
+// import org.springframework.security.config.Customizer;
+// import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+// import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+// import org.springframework.security.web.SecurityFilterChain;
 
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
+// @Configuration
+// @EnableWebSecurity
+// public class SecurityConfig {
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(
-                        (csrfConfig) -> csrfConfig.disable()
-                )
-                .headers(
-                        (headerConfig) -> headerConfig.frameOptions(
-                                frameOptionsConfig -> frameOptionsConfig.disable()
-                        )
-                )
-                .authorizeHttpRequests((authorizeRequest) -> authorizeRequest
-                        .requestMatchers("/", "/css/**", "images/**", "/js/**", "/login/*", "/logout/*", "/api/auth/**", "/api/books/**", "/api/**", "api/auth/login", "/api/alim-inf","/api/alim-inf/**", "/api/books/generate_fairytale","/api/baby-photos/**","/api/baby-photos/baby/", "/api/books/user/**", "/api/alim-inf/alim-id/**","/api/chat/send/**").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .logout(
-                        (logoutConfig) -> logoutConfig.logoutSuccessUrl("/")
-                )
-                .oauth2Login(Customizer.withDefaults());
+//     @Bean
+//     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+//         http
+//                 .csrf(
+//                         (csrfConfig) -> csrfConfig.disable()
+//                 )
+//                 .headers(
+//                         (headerConfig) -> headerConfig.frameOptions(
+//                                 frameOptionsConfig -> frameOptionsConfig.disable()
+//                         )
+//                 )
+//                 .authorizeHttpRequests((authorizeRequest) -> authorizeRequest
+//                         .requestMatchers("/", "/css/**", "images/**", "/js/**", "/login/*", "/logout/*", "/api/auth/**", "/api/books/**", "/api/**", "api/auth/login", "/api/alim-inf","/api/alim-inf/**", "/api/books/generate_fairytale","/api/baby-photos/**","/api/baby-photos/baby/", "/api/books/user/**", "/api/alim-inf/alim-id/**","/api/chat/send/**").permitAll()
+//                         .anyRequest().authenticated()
+//                 )
+//                 .logout(
+//                         (logoutConfig) -> logoutConfig.logoutSuccessUrl("/")
+//                 )
+//                 .oauth2Login(Customizer.withDefaults());
 
-        return http.build();
-    }
-}
+//         return http.build();
+//     }
+// }

--- a/src/main/java/com/example/finalproj/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/finalproj/security/JwtTokenProvider.java
@@ -1,55 +1,55 @@
-package com.example.finalproj.security;
+// package com.example.finalproj.security;
 
-import io.jsonwebtoken.*;
-import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+// import io.jsonwebtoken.*;
+// import io.jsonwebtoken.security.Keys;
+// import jakarta.annotation.PostConstruct;
+// import org.springframework.beans.factory.annotation.Value;
+// import org.springframework.stereotype.Component;
 
-import java.security.Key;
-import java.util.Date;
+// import java.security.Key;
+// import java.util.Date;
 
-@Component
-public class JwtTokenProvider {
+// @Component
+// public class JwtTokenProvider {
 
-    @Value("${jwt.expiration}")
-    private int jwtExpiration;
+//     @Value("${jwt.expiration}")
+//     private int jwtExpiration;
 
-    private Key key;
+//     private Key key;
 
-    @PostConstruct
-    public void init() {
-        this.key = Keys.secretKeyFor(SignatureAlgorithm.HS512);
-    }
+//     @PostConstruct
+//     public void init() {
+//         this.key = Keys.secretKeyFor(SignatureAlgorithm.HS512);
+//     }
 
-    public String generateToken(Integer userId) {
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + jwtExpiration);
+//     public String generateToken(Integer userId) {
+//         Date now = new Date();
+//         Date expiryDate = new Date(now.getTime() + jwtExpiration);
 
-        return Jwts.builder()
-                .setSubject(Integer.toString(userId))
-                .setIssuedAt(new Date())
-                .setExpiration(expiryDate)
-                .signWith(key, SignatureAlgorithm.HS512)
-                .compact();
-    }
+//         return Jwts.builder()
+//                 .setSubject(Integer.toString(userId))
+//                 .setIssuedAt(new Date())
+//                 .setExpiration(expiryDate)
+//                 .signWith(key, SignatureAlgorithm.HS512)
+//                 .compact();
+//     }
 
-    public Integer getUserIdFromToken(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+//     public Integer getUserIdFromToken(String token) {
+//         Claims claims = Jwts.parserBuilder()
+//                 .setSigningKey(key)
+//                 .build()
+//                 .parseClaimsJws(token)
+//                 .getBody();
 
-        return Integer.parseInt(claims.getSubject());
-    }
+//         return Integer.parseInt(claims.getSubject());
+//     }
 
-    public boolean validateToken(String token) {
-        try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
-        }
-    }
-}
+//     public boolean validateToken(String token) {
+//         try {
+//             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+//             return true;
+//         } catch (JwtException | IllegalArgumentException e) {
+//             return false;
+//         }
+//     }
+// }

--- a/src/main/java/com/example/finalproj/user/controller/UserController.java
+++ b/src/main/java/com/example/finalproj/user/controller/UserController.java
@@ -4,7 +4,7 @@ import com.example.finalproj.baby.service.BabyService;
 import com.example.finalproj.user.entity.User;
 import com.example.finalproj.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.util.Value;
+// import com.google.api.client.util.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,21 +66,21 @@ public class UserController {
         }
     }
 
-    @Value("${google.client.id}")
-    private String clientId;
+    // @Value("${google.client.id}")
+    // private String clientId;
 
-    @Value("${google.client.secret}")
-    private String clientSecret;
+    // @Value("${google.client.secret}")
+    // private String clientSecret;
 
-    @Value("${google.redirect.uri}")
-    private String redirectUri;
+    // @Value("${google.redirect.uri}")
+    // private String redirectUri;
 
-    // OAuth URL 생성 시 포함
-    String authUrl = "https://accounts.google.com/o/oauth2/auth" +
-            "?client_id=" + clientId +
-            "&redirect_uri=" + "http://localhost:3000/api/auth/google/callback" + // 여기에서 redirectUri가 null이면 안 됩니다.
-            "&response_type=code" +
-            "&scope=email%20profile";
+    // // OAuth URL 생성 시 포함
+    // String authUrl = "https://accounts.google.com/o/oauth2/auth" +
+    //         "?client_id=" + clientId +
+    //         "&redirect_uri=" + "http://localhost:3000/api/auth/google/callback" + // 여기에서 redirectUri가 null이면 안 됩니다.
+    //         "&response_type=code" +
+    //         "&scope=email%20profile";
 
     // Google 사용자 인증
 //    @PostMapping("/google")
@@ -115,100 +115,100 @@ public class UserController {
 //        }
 //    }
 
-    // Google 인증 URL 반환
-    @GetMapping("/google-url")
-    public ResponseEntity<Map<String, String>> getGoogleAuthUrl() {
-        String authUrl = "https://accounts.google.com/o/oauth2/auth" +
-                "?client_id=" + clientId +
-                "&redirect_uri=" + redirectUri +
-                "&response_type=code" +
-                "&scope=email%20profile";
+    // // Google 인증 URL 반환
+    // @GetMapping("/google-url")
+    // public ResponseEntity<Map<String, String>> getGoogleAuthUrl() {
+    //     String authUrl = "https://accounts.google.com/o/oauth2/auth" +
+    //             "?client_id=" + clientId +
+    //             "&redirect_uri=" + redirectUri +
+    //             "&response_type=code" +
+    //             "&scope=email%20profile";
 
-        Map<String, String> response = new HashMap<>();
-        response.put("url", authUrl);
-        return ResponseEntity.ok(response);
-    }
+    //     Map<String, String> response = new HashMap<>();
+    //     response.put("url", authUrl);
+    //     return ResponseEntity.ok(response);
+    // }
 
 
-    // Google Callback 처리
-    @PostMapping("/google-callback")
-    public ResponseEntity<?> handleGoogleCallback(@RequestBody Map<String, String> body) {
-        String code = body.get("code");
-        try {
-            String tokenResponse = exchangeCodeForToken(code);
-            Map<String, Object> userInfo = getUserInfo(tokenResponse);
-            String jwtToken = generateJwtToken(userInfo);
+    // // Google Callback 처리
+    // @PostMapping("/google-callback")
+    // public ResponseEntity<?> handleGoogleCallback(@RequestBody Map<String, String> body) {
+    //     String code = body.get("code");
+    //     try {
+    //         String tokenResponse = exchangeCodeForToken(code);
+    //         Map<String, Object> userInfo = getUserInfo(tokenResponse);
+    //         String jwtToken = generateJwtToken(userInfo);
 
-            Map<String, String> response = new HashMap<>();
-            response.put("token", jwtToken);
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            logger.error("Error handling Google callback", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("Error processing Google callback: " + e.getMessage());
-        }
-    }
+    //         Map<String, String> response = new HashMap<>();
+    //         response.put("token", jwtToken);
+    //         return ResponseEntity.ok(response);
+    //     } catch (Exception e) {
+    //         logger.error("Error handling Google callback", e);
+    //         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+    //                 .body("Error processing Google callback: " + e.getMessage());
+    //     }
+    // }
 
-    private String exchangeCodeForToken(String code) {
-        RestTemplate restTemplate = new RestTemplate();
+    // private String exchangeCodeForToken(String code) {
+    //     RestTemplate restTemplate = new RestTemplate();
 
-        String tokenUrl = "https://oauth2.googleapis.com/token";
-        Map<String, String> requestBody = new HashMap<>();
-        requestBody.put("code", code);
-        requestBody.put("client_id", clientId);
-        requestBody.put("client_secret", clientSecret);
-        requestBody.put("redirect_uri", redirectUri);
-        requestBody.put("grant_type", "authorization_code");
+    //     String tokenUrl = "https://oauth2.googleapis.com/token";
+    //     Map<String, String> requestBody = new HashMap<>();
+    //     requestBody.put("code", code);
+    //     requestBody.put("client_id", clientId);
+    //     requestBody.put("client_secret", clientSecret);
+    //     requestBody.put("redirect_uri", redirectUri);
+    //     requestBody.put("grant_type", "authorization_code");
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "application/x-www-form-urlencoded");
+    //     HttpHeaders headers = new HttpHeaders();
+    //     headers.add("Content-Type", "application/x-www-form-urlencoded");
 
-        HttpEntity<Map<String, String>> entity = new HttpEntity<>(requestBody, headers);
+    //     HttpEntity<Map<String, String>> entity = new HttpEntity<>(requestBody, headers);
 
-        ResponseEntity<String> response = restTemplate.postForEntity(tokenUrl, entity, String.class);
-        return response.getBody();
-    }
+    //     ResponseEntity<String> response = restTemplate.postForEntity(tokenUrl, entity, String.class);
+    //     return response.getBody();
+    // }
 
-    private Map<String, Object> getUserInfo(String tokenResponse) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            Map<String, String> tokenMap = mapper.readValue(tokenResponse, Map.class);
-            String accessToken = tokenMap.get("access_token");
+    // private Map<String, Object> getUserInfo(String tokenResponse) {
+    //     try {
+    //         ObjectMapper mapper = new ObjectMapper();
+    //         Map<String, String> tokenMap = mapper.readValue(tokenResponse, Map.class);
+    //         String accessToken = tokenMap.get("access_token");
 
-            RestTemplate restTemplate = new RestTemplate();
-            String userInfoUrl = "https://www.googleapis.com/oauth2/v2/userinfo";
+    //         RestTemplate restTemplate = new RestTemplate();
+    //         String userInfoUrl = "https://www.googleapis.com/oauth2/v2/userinfo";
 
-            HttpHeaders headers = new HttpHeaders();
-            headers.add("Authorization", "Bearer " + accessToken);
+    //         HttpHeaders headers = new HttpHeaders();
+    //         headers.add("Authorization", "Bearer " + accessToken);
 
-            HttpEntity<String> entity = new HttpEntity<>("", headers);
-            ResponseEntity<String> response = restTemplate.exchange(userInfoUrl, HttpMethod.GET, entity, String.class);
+    //         HttpEntity<String> entity = new HttpEntity<>("", headers);
+    //         ResponseEntity<String> response = restTemplate.exchange(userInfoUrl, HttpMethod.GET, entity, String.class);
 
-            return mapper.readValue(response.getBody(), Map.class); // Map containing user info
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to get user info", e);
-        }
-    }
+    //         return mapper.readValue(response.getBody(), Map.class); // Map containing user info
+    //     } catch (Exception e) {
+    //         throw new RuntimeException("Failed to get user info", e);
+    //     }
+    // }
 
-    private String generateJwtToken(Map<String, Object> userInfo) {
-        // Implement JWT generation logic using the userInfo map.
-        // This could include adding claims like user ID, email, roles, etc.
-        // You might want to use a library like JJWT or Spring Security's JWT support.
+    // private String generateJwtToken(Map<String, Object> userInfo) {
+    //     // Implement JWT generation logic using the userInfo map.
+    //     // This could include adding claims like user ID, email, roles, etc.
+    //     // You might want to use a library like JJWT or Spring Security's JWT support.
 
-        // For example:
-        String email = (String) userInfo.get("email");
-        String name = (String) userInfo.get("name");
+    //     // For example:
+    //     String email = (String) userInfo.get("email");
+    //     String name = (String) userInfo.get("name");
 
-        // Pseudo code for generating JWT:
-        // return JWT.create()
-        //          .withSubject(email)
-        //          .withClaim("name", name)
-        //          .withExpiresAt(expirationDate)
-        //          .sign(algorithm);
+    //     // Pseudo code for generating JWT:
+    //     // return JWT.create()
+    //     //          .withSubject(email)
+    //     //          .withClaim("name", name)
+    //     //          .withExpiresAt(expirationDate)
+    //     //          .sign(algorithm);
 
-        // For now, return a dummy token for illustration purposes
-        return "jwt_token_" + System.currentTimeMillis();
-    }
+    //     // For now, return a dummy token for illustration purposes
+    //     return "jwt_token_" + System.currentTimeMillis();
+    // }
 
 //    @PostMapping("/dev-login")
 //    public ResponseEntity<?> devLogin() {

--- a/src/main/java/com/example/finalproj/user/service/UserService.java
+++ b/src/main/java/com/example/finalproj/user/service/UserService.java
@@ -21,11 +21,11 @@ public class UserService {
 //
     public void createDummyUser() {
         // Check if the user already exists
-        Optional<User> existingUser = findUserByIdAndEmail(1, "chulsoo@example.com");
+        Optional<User> existingUser = findUserByIdAndEmail(3, "mmongeul@gmail.com");
         if (!existingUser.isPresent()) {
             User dummyUser = new User();
-            dummyUser.setUserId(1);
-            dummyUser.setEmail("chulsoo@example.com");
+            dummyUser.setUserId(3);
+            dummyUser.setEmail("mmongeul@gmail.com");
             dummyUser.setName("Dummy User");
             dummyUser.setNewUser(true); // Adjust as necessary
             // Save the dummy user to the database

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,18 +1,18 @@
 spring:
-  security:
-    user:
-      name: ${SPRING_SECURITY_ID}
-      password: ${SPRING_SECURITY_PWD}
-    oauth2:
-      client:
-        registration:
-          google:
-            client-id: ${GOOGLE_CLIENT_ID}
-            client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: http://localhost:8080/api/auth/google-callback
-            scope:
-              - email
-              - profile
+  # security:
+  #   user:
+  #     name: ${SPRING_SECURITY_ID}
+  #     password: ${SPRING_SECURITY_PWD}
+  #   oauth2:
+  #     client:
+  #       registration:
+  #         google:
+  #           client-id: ${GOOGLE_CLIENT_ID}
+  #           client-secret: ${GOOGLE_CLIENT_SECRET}
+  #           redirect-uri: http://localhost:8080/api/auth/google-callback
+  #           scope:
+  #             - email
+  #             - profile
   datasource:
     url: ${DB_URL}
     username: ${DB_USER}
@@ -62,10 +62,10 @@ logging:
     org.springframework.web: WARN
     org.hibernate.SQL: WARN
 
-jwt:
-  secret: ${JWT_SECRET}
-  expiration: ${JWT_EXPIRATION:86400000}
+# jwt:
+#   secret: ${JWT_SECRET}
+#   expiration: ${JWT_EXPIRATION:86400000}
 
-google:
-  client:
-    id: ${GOOGLE_CLIENT_ID}
+# google:
+#   client:
+#     id: ${GOOGLE_CLIENT_ID}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[Branch][debug/auth-related-code]

- commit version(HEAD), 09/26 오후
    - Final-front origin/develop : `ca73240352f6b6557a1775606ba6f63e8051e073`
    - Final-back origin/develop : `a4906ae4914202f629a43592ebbb475c98f78e31`

### 💡 작업동기
- 알수없는부분에서 nextauth, oauth 등 인증문제 발생
- 모든 인증관련 위치 파악 필요
- 시큐리티 관련 코드 디버깅 필요

### 🔑 주요 변경사항
- frontend 부분 nextauth관련파일 제거(브랜치는 따로 안만듦)
```javascript
deleted:    app/api/auth/[...nextauth]/route.ts
```
- backend 관련코드 주석처리
```javascript
// 인증 관련 코드 위치:
build.gradle
src/main/java/com/example/finalproj/config/auth/SecurityConfig.java
src/main/java/com/example/finalproj/security/JwtTokenProvider.java
src/main/java/com/example/finalproj/user/controller/UserController.java 
src/main/java/com/example/finalproj/user/service/UserService.java // 시큐리티관련 X
src/main/resources/application.yml
```
1. `build.gradle`
    - security, oauth, google, jwt 관련 의존성 주석처리
2. `SecurityConfig.java`
    - 시큐리티 설정 코드 주석처리
3. `JwtTokenProvider.java`
    - jwt토큰발급 코드 주석처리
4. `UserController.java`
    - 유저 관련 api호출에서 oauth 참조하는 부분 전부 주석처리
5.  `UserService.java`
    - (시큐리티관련 X) 더미유저 로그인
6. `application.yml`
    - security, oauth, jwt 참조 부분 주석처리

### 결과
- 주석처리 후 더미유저로 api 호출 시 oauth 인증 문제 사라짐
- 캘린더 ocr, 등록 문제없음
- 메모, 일정 crud 확인
- embedding 생성 확인
- babydiary 일기 생성 x, 텍스트 그대로 들어감

![image](https://github.com/user-attachments/assets/ce7f4c43-14fc-499c-9c91-9bb748975a34)

### 이슈

- 동화생성 클릭 시 504에러 발생 

![image](https://github.com/user-attachments/assets/f547c694-fb5c-4144-b1b0-df3c0b9ed01d)

```bash
ml-1        | INFO:     172.18.0.1:57902 - "POST /generate_fairytale HTTP/1.1" 200 OK
backend-1   | 2024-09-26T08:10:09.214Z  WARN 1 --- [nio-8080-exec-6] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.web.HttpRequestMethodNotSupportedException: Request method 'POST' is not supported]
```

- babydiary 일기 생성 x, 텍스트 그대로 들어감
    - 일기 생성 부분 확인 필요



