### PR TITLE
[에러 해결] 가정통신문 ml 결과를 받는 중 사용되는 api auth 허용

### DIFF
--- a/src/main/java/com/example/finalproj/config/SecurityConfig.java
+++ b/src/main/java/com/example/finalproj/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                         sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(authorizeRequest -> authorizeRequest
-                        .requestMatchers("/api/auth/validate-token" ,"/api/auth/google-callback","/api/auth/google-url", "/", "/css/**", "images/**", "/js/**", "/login/*", "/logout/*").permitAll()
+                        .requestMatchers("/api/calendar-photo-inf/*","/api/auth/validate-token" ,"/api/auth/google-callback","/api/auth/google-url", "/", "/css/**", "images/**", "/js/**", "/login/*", "/logout/*").permitAll()
                         .anyRequest().authenticated()
                 )
                 .logout(logoutConfig -> logoutConfig.logoutSuccessUrl("/"))

--- a/src/main/java/com/example/finalproj/ml/calendarML/CalendarMLEventListener.java
+++ b/src/main/java/com/example/finalproj/ml/calendarML/CalendarMLEventListener.java
@@ -35,7 +35,6 @@ public class CalendarMLEventListener {
 
             ResponseEntity<String> forwardResponse = restTemplate.postForEntity(forwardUrl, request, String.class);
             System.out.println("Calendar Photo Inf Controller response: " + forwardResponse.getBody());
-            System.out.println("Calendar Photo Inf Controller response: " + forwardResponse.getHeaders());
         } catch (Exception e) {
             System.err.println("Error forwarding ML response: " + e.getMessage());
         }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[Branch][Feature/alimInfAuthError]

### 💡 작업동기
- 작업 배경을 알려주세요.

### 🔑 주요 변경사항
- 가정통신문 ml 결과를 받는 중 사용되는 /api/calendar-photo-inf/* api auth 허용
- 
### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈
- 관련 이슈를 입력해주세요.

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
